### PR TITLE
Fix cowlib dep versioning issues in CI 

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,10 +3,10 @@ name: Elixir CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   build:
@@ -24,7 +24,7 @@ jobs:
           - elixir: "1.16"
             otp: "26"
             should_lint: true
-          
+
           - elixir: "1.15"
             otp: "24"
           - elixir: "1.15"
@@ -40,16 +40,12 @@ jobs:
             otp: "25"
 
           - elixir: "1.13"
-            otp: "22"
-          - elixir: "1.13"
             otp: "23"
           - elixir: "1.13"
             otp: "24"
           - elixir: "1.13"
             otp: "25"
 
-          - elixir: "1.12"
-            otp: "22"
           - elixir: "1.12"
             otp: "23"
           - elixir: "1.12"
@@ -86,15 +82,5 @@ jobs:
       - name: Run Azurite in Background
         shell: bash
         run: azurite-blob &
-      - name: Create integration test containers in Azurex
-        run: |
-          mix run -e '
-            Application.put_env(:azurex, Azurex.Blob.Config, storage_account_connection_string:
-              "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1"
-            )
-            Azurex.Blob.Container.create(~s{test})
-            Azurex.Blob.Container.create(~s{integrationtestingcontainer})
-            Azurex.Blob.put_blob("test_blob", "test_blob_content", "text", "test")
-          '
       - name: Run Tests
         run: mix test --include integration

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,11 +46,6 @@ jobs:
           - elixir: "1.13"
             otp: "25"
 
-          - elixir: "1.12"
-            otp: "23"
-          - elixir: "1.12"
-            otp: "24"
-
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Fix elixir OTP matrix to use supported versions for cowlib dep
- Remove unneeded configuration in ci.yml, already being done in test_helper and test setups