### PR TITLE
Make bearer token :ets tables public + testing edge case

### DIFF
--- a/lib/azurex/authorization/managed_identity.ex
+++ b/lib/azurex/authorization/managed_identity.ex
@@ -2,6 +2,7 @@ defmodule Azurex.Authorization.ManagedIdentity do
   require Logger
   alias Azurex.Blob.Config
 
+  @ets_table_name :managed_identity_bearer_token_cache
   @cache_key "azurex_bearer_token"
   @cache_expiry_margin_seconds 10
 
@@ -21,13 +22,13 @@ defmodule Azurex.Authorization.ManagedIdentity do
   end
 
   defp fetch_bearer_token_cached(client_id, tenant_id, identity_token) do
-    if :ets.info(:bearer_token_cache) == :undefined do
-      :ets.new(:bearer_token_cache, [:named_table])
+    if :ets.info(@ets_table_name) == :undefined do
+      :ets.new(@ets_table_name, [:named_table, :public])
     end
 
     system_os_time = System.os_time(:second)
 
-    case :ets.lookup(:bearer_token_cache, @cache_key) do
+    case :ets.lookup(@ets_table_name, @cache_key) do
       [{@cache_key, token, expiry}] when expiry > system_os_time -> token
       _ -> refresh_bearer_token_cache(client_id, tenant_id, identity_token)
     end
@@ -37,7 +38,7 @@ defmodule Azurex.Authorization.ManagedIdentity do
     case fetch_bearer_token(client_id, tenant_id, identity_token) do
       {:ok, %{"access_token" => token, "expires_in" => expires_in}} ->
         expiry = System.os_time(:second) + expires_in - @cache_expiry_margin_seconds
-        :ets.insert(:bearer_token_cache, {@cache_key, token, expiry})
+        :ets.insert(@ets_table_name, {@cache_key, token, expiry})
         token
 
       :error ->

--- a/lib/azurex/authorization/service_principal.ex
+++ b/lib/azurex/authorization/service_principal.ex
@@ -2,6 +2,7 @@ defmodule Azurex.Authorization.ServicePrincipal do
   require Logger
   alias Azurex.Blob.Config
 
+  @ets_table_name :service_principal_bearer_token_cache
   @cache_key "azurex_bearer_token"
   @cache_expiry_margin_seconds 10
 
@@ -23,10 +24,10 @@ defmodule Azurex.Authorization.ServicePrincipal do
   defp fetch_bearer_token_cached(client_id, client_secret, tenant_id) do
     cache_key = @cache_key
 
-    :ets.info(:bearer_token_cache) != :undefined ||
-      :ets.new(:bearer_token_cache, [:named_table])
+    :ets.info(@ets_table_name) != :undefined ||
+      :ets.new(@ets_table_name, [:named_table, :public])
 
-    case :ets.lookup(:bearer_token_cache, cache_key) do
+    case :ets.lookup(@ets_table_name, cache_key) do
       [{^cache_key, token, expiry}] ->
         if expiry > System.os_time(:second) do
           token
@@ -43,7 +44,7 @@ defmodule Azurex.Authorization.ServicePrincipal do
     case fetch_bearer_token(client_id, client_secret, tenant_id) do
       {:ok, token} ->
         expiry = extract_expiry_time(token) - @cache_expiry_margin_seconds
-        :ets.insert(:bearer_token_cache, {@cache_key, token, expiry})
+        :ets.insert(@ets_table_name, {@cache_key, token, expiry})
         token
 
       :error ->

--- a/test/azurex/authorization/managed_identity_test.exs
+++ b/test/azurex/authorization/managed_identity_test.exs
@@ -104,6 +104,50 @@ defmodule Azurex.Authorization.ManagedIdentityTest do
       end
     end
 
+    test "bearer cache works across processes", %{bypass: bypass} do
+      federated_token_file_path = create_token_file()
+
+      # Set token time so it expires in 100 seconds
+      token_expires_in = :timer.seconds(-100)
+      input_request = generate_request()
+
+      # Expect one token request because the second will be cached
+      prepare_auth_endpoint(bypass, token_expires_in)
+
+      # Fetch bearer token and cache
+      assert %HTTPoison.Request{} =
+               ManagedIdentity.add_bearer_token(
+                 input_request,
+                 "client_id",
+                 "tenant_id",
+                 federated_token_file_path
+               )
+
+      task =
+        Task.async(fn ->
+          prepare_auth_endpoint(bypass, token_expires_in)
+
+          ManagedIdentity.add_bearer_token(
+            input_request,
+            "client_id",
+            "tenant_id",
+            federated_token_file_path
+          )
+        end)
+
+      assert Task.await(task) == %HTTPoison.Request{
+               body: "sample body",
+               headers: [
+                 {"Authorization", "Bearer #{@expected_access_token}"},
+                 {"x-ms-blob-type", "BlockBlob"}
+               ],
+               method: :put,
+               options: [recv_timeout: :infinity],
+               params: %{},
+               url: "https://example.com/sample-path"
+             }
+    end
+
     test "Failure", %{bypass: bypass} do
       federated_token_file_path = create_token_file()
 

--- a/test/azurex/authorization/service_principal_test.exs
+++ b/test/azurex/authorization/service_principal_test.exs
@@ -100,6 +100,48 @@ defmodule Azurex.Authorization.ServicePrincipalTest do
       end
     end
 
+    test "bearer cache works across processes", %{bypass: bypass} do
+      # Set token time so it expires in 100 seconds
+      t = generate_token(:timer.seconds(-100))
+      input_request = generate_request()
+
+      # Expect one token request because the second will be cached
+      prepare_auth_enpoint(bypass, t)
+
+      # Fetch bearer token and cache
+      assert %HTTPoison.Request{} =
+               ServicePrincipal.add_bearer_token(
+                 input_request,
+                 "client_id",
+                 "client_secret",
+                 "tenant_id"
+               )
+
+      task =
+        Task.async(fn ->
+          prepare_auth_enpoint(bypass, t)
+
+          ServicePrincipal.add_bearer_token(
+            input_request,
+            "client_id",
+            "client_secret",
+            "tenant_id"
+          )
+        end)
+
+      assert Task.await(task) == %HTTPoison.Request{
+               body: "sample body",
+               headers: [
+                 {"Authorization", "Bearer #{t}"},
+                 {"x-ms-blob-type", "BlockBlob"}
+               ],
+               method: :put,
+               options: [recv_timeout: :infinity],
+               params: %{},
+               url: "https://example.com/sample-path"
+             }
+    end
+
     test "Failure", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/tenant_id/oauth2/v2.0/token", fn conn ->
         Plug.Conn.resp(conn, 403, "Not authorized")


### PR DESCRIPTION
Found an edge case when fetching new bearer tokens in different processes